### PR TITLE
bump to v1.7.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ include $(TOPDIR)/rules.mk
 
 NAME:=parentcontrol
 PKG_NAME:=luci-app-$(NAME)
-PKG_VERSION:=1.7.1
-PKG_RELEASE:=20230909
+PKG_VERSION:=1.7.2
+PKG_RELEASE:=20250317
 PKG_LICENSE:=Apache-2.0
 
 LUCI_TITLE:=LuCI support for Parent Control

--- a/root/etc/uci-defaults/luci-app-parentcontrol
+++ b/root/etc/uci-defaults/luci-app-parentcontrol
@@ -1,11 +1,13 @@
 #!/bin/sh
 
+[ -e "/etc/config/ucitrack" ] && {
 uci -q batch <<-EOF >/dev/null
 	delete ucitrack.@parentcontrol[-1]
 	add ucitrack parentcontrol
 	set ucitrack.@parentcontrol[-1].init=parentcontrol
 	commit ucitrack
 EOF
+}
 
 uci -q delete firewall.parentcontrol
 uci -q set firewall.parentcontrol=include

--- a/root/usr/share/ucitrack/luci-app-parentcontrol.json
+++ b/root/usr/share/ucitrack/luci-app-parentcontrol.json
@@ -1,0 +1,4 @@
+{
+	"config": "parentcontrol",
+	"init": "parentcontrol"
+}


### PR DESCRIPTION
修复无法运行。注意，点击运行后，还要点击针对某个机器的 开启 按钮，才会运行。